### PR TITLE
deleted tinyarchive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 tinyarchive/tinyenv/*
-
+tinylibs/*
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tinyarchive.env
+++ b/tinyarchive.env
@@ -1,1 +1,0 @@
-source ../../denv/bin/activate


### PR DESCRIPTION
Removed the env file that didn't do anything and made it so that people don't accidentally push the virtualenv files from the tutorial.